### PR TITLE
fix: support installing latest Ape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
       - uses: ApeWorX/github-action@v1
         with:
           python-version: '3.9'
-          ape-version-pin: '==0.5.2'
-
-      - name: Install Vyper
-        run: pip install git+https://github.com/vyperlang/vyper@v0.3.7
 
       - name: Compile contracts
         run: ape compile --force --size


### PR DESCRIPTION
Until the next Vyper is released, Ape won't work well with installs with Vyper in the same Python env.
I noticed Vyper is not used here.

Plus, even if it was, installing Vyper in the same Python env may not be needed. `ape-vyper` uses `vvm` by default.